### PR TITLE
Only try to start Kst if it actually exists

### DIFF
--- a/fsLogger.ps1
+++ b/fsLogger.ps1
@@ -76,7 +76,7 @@ while ($global:fsConnected) {
 		$str | Out-File "$csvfile" -Append -Encoding UTF8 
 		
 		# Start KST if it has closed
-		if ($startKST) { 
+		if ($startKST -and (Test-Path -path ".\Kst\bin\kst2.exe")) { 
 			if ([math]::Round($t_new/4) -gt [math]::Round($t_prev/4) ) {
 				$kstproc = Get-Process kst2 -ErrorAction SilentlyContinue
 				if (!$kstproc) {


### PR DESCRIPTION
If the right flags are set, it tries to start Kst. If it doesn't exist, then the user gets error messages. This change means it will no longer try to start Kst if it doesn't actually exist.